### PR TITLE
Add a margin to ensure the timeline is visible

### DIFF
--- a/packages/react-app/src/SmartContractWallet.js
+++ b/packages/react-app/src/SmartContractWallet.js
@@ -109,7 +109,7 @@ export default function SmartContractWallet(props) {
           </List.Item>
         )}
       />
-      <div style={{position:'fixed',textAlign:'right',right:25,top:90,padding:10,width:"50%"}}>
+      <div style={{position:'fixed',textAlign:'right',right:25,top:90,padding:10,width:"50%",marginRight: "15%"}}>
         <h1>✅ TODO LIST</h1>
         <Timeline
           localProvider={props.localProvider}


### PR DESCRIPTION
Current timeline is clipped on at least standard Macbook Pro display (although - seems it would be on any display). This pushes it over to not conflict with other text.

Note: Might have mobile considerations, but not sure how many people will be doing DApp development on mobile quite yet 😛 

**Current**:
![image](https://user-images.githubusercontent.com/4511854/81200419-ee581000-8f91-11ea-8ce7-220b4524796a.png)

**New**:
![image](https://user-images.githubusercontent.com/4511854/81200442-f4e68780-8f91-11ea-99be-dacda43b0ad1.png)
