### PR TITLE
Prevent 'deploy.js' script from crashing on interface artifacts

### DIFF
--- a/packages/buidler/scripts/deploy.js
+++ b/packages/buidler/scripts/deploy.js
@@ -6,6 +6,10 @@ async function main() {
     if(contractList[c].indexOf(".json")>=0 && contractList[c].indexOf(".swp.")<0){
       const name = contractList[c].replace(".json","")
       const contractArtifacts = artifacts.require(name);
+      if (contractArtifacts.toJSON().bytecode === '0x'){
+        console.log(chalk.cyan(name), "is abstract, does not implement an abstract parent's method, or is an interface");
+        continue;
+      }
       const contract = await contractArtifacts.new()
       console.log(chalk.cyan(name),"deployed to:", chalk.magenta(contract.address));
       fs.writeFileSync("artifacts/"+name+".address",contract.address);


### PR DESCRIPTION
In case a smart contract implements an interface, budler will create an
artifact JSON file for that interface as well.
Attempt to call '.new()' on this artifact crashes the deployer srcipt.