### PR TITLE
Fix module hoisthing problem and avoid buggy version of buidler

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "send": "cd packages/buidler && npx buidler send"
   },
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.3.0",
-    "@nomiclabs/buidler-truffle5": "^1.3.0",
-    "@nomiclabs/buidler-web3": "^1.3.0"
+    "@nomiclabs/buidler": "1.3.3-rc.0",
+    "@nomiclabs/buidler-truffle5": "1.3.3-rc.0",
+    "@nomiclabs/buidler-web3": "1.3.3-rc.0"
   },
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
     "balance": "cd packages/buidler && npx buidler balance",
     "send": "cd packages/buidler && npx buidler send"
   },
+  "devDependencies": {
+    "@nomiclabs/buidler": "^1.3.0",
+    "@nomiclabs/buidler-truffle5": "^1.3.0",
+    "@nomiclabs/buidler-web3": "^1.3.0"
+  },
   "workspaces": {
     "packages": [
       "packages/*"

--- a/packages/buidler/package.json
+++ b/packages/buidler/package.json
@@ -4,9 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.3.0",
-    "@nomiclabs/buidler-truffle5": "^1.3.0",
-    "@nomiclabs/buidler-web3": "^1.3.0",
     "web3": "^1.2.6"
   },
   "dependencies": {


### PR DESCRIPTION
As stated in yarn documentation here:
https://classic.yarnpkg.com/en/docs/workspaces/#toc-limitations-caveats

"The package layout will be different between your workspace and what
your users will get." Unfortunately, 'budler' searches for plugins in
the project root's ./node_modules/ folder, which is not guaranteed to
work with yarn workspaces.

Declaring all buidler dependencies in a root package.json seems to
resolve the issue.


=====

Also, the buidler version is updated to include the following fix:
https://github.com/nomiclabs/buidler/pull/540