### PR TITLE
Better description, comment out GSN, Limit as string

### DIFF
--- a/packages/react-app/src/InkCanvas.js
+++ b/packages/react-app/src/InkCanvas.js
@@ -89,13 +89,13 @@ export default function InkCanvas(props) {
 
   const mintInk = async (inkUrl, jsonUrl) => {
     let result
-    try {
+    /*try {
       console.log('trying meta-transaction')
     result = await tx(metaWriteContracts["NFTINK"].createInk(inkUrl, jsonUrl, props.ink.attributes[0]['value']))
-    } catch {
-      console.log('the old fashioned way')
+  } catch {
+      console.log('the old fashioned way')*/
     result = await tx(writeContracts["NFTINK"].createInk(inkUrl, jsonUrl, props.ink.attributes[0]['value']))
-    }
+    //}
     console.log("result", result)
     return result
   }
@@ -115,9 +115,17 @@ export default function InkCanvas(props) {
 
     currentInk['attributes'] = [{
       "trait_type": "Limit",
-      "value": values.limit
+      "value": values.limit.toString()
     }]
     currentInk['name'] = values.title
+    let newEns
+    try {
+      newEns = await props.mainnetProvider.lookupAddress(props.address)
+    } catch (e) { console.log(e) }
+    const timeInMs = new Date()
+    console.log(newEns, !newEns, props.address, timeInMs.toUTCString())
+    const addressForDescription = !newEns?props.address:newEns
+    currentInk['description'] = 'A Nifty Ink by ' + addressForDescription + ' on ' + timeInMs.toUTCString()
 
     props.setIpfsHash()
 

--- a/packages/react-app/src/InkInfo.js
+++ b/packages/react-app/src/InkInfo.js
@@ -136,6 +136,7 @@ useEffect(()=>{
               <Descriptions.Item label="Image">{props.ink.image}</Descriptions.Item>
               <Descriptions.Item label="Count">{inkChainInfo[2].toString()}</Descriptions.Item>
               <Descriptions.Item label="Limit">{props.ink.attributes[0].value}</Descriptions.Item>
+              <Descriptions.Item label="Description">{props.ink.description}</Descriptions.Item>
             </Descriptions>
           )
 

--- a/packages/react-app/src/InkInfo.js
+++ b/packages/react-app/src/InkInfo.js
@@ -79,7 +79,7 @@ export default function InkInfo(props) {
         }
         //<Typography.Text>{'Token ID: ' + item[1] + " owned by "}</Typography.Text>
         let mintDescription
-        if(props.ink.attributes[0].value === 0) {
+        if(props.ink.attributes[0].value === "0") {
           mintDescription = (inkChainInfo[2] + ' minted')
         }
         else {mintDescription = (inkChainInfo[2] + '/' + props.ink.attributes[0].value + ' minted')}
@@ -127,7 +127,6 @@ useEffect(()=>{
       )
     } else {
       if(inkChainInfo && props.ink.attributes) {
-        if(props.address === inkChainInfo[1] && (inkChainInfo[2] < props.ink.attributes[0].value || props.ink.attributes[0].value === 0)) {
 
           detailContent = (
             <Descriptions>
@@ -140,6 +139,7 @@ useEffect(()=>{
             </Descriptions>
           )
 
+      if(props.address === inkChainInfo[1] && (inkChainInfo[2] < Number(props.ink.attributes[0].value) || props.ink.attributes[0].value === "0")) {
           const mintForm = (
             <Row style={{justifyContent: 'center'}}>
 


### PR DESCRIPTION
- Adding a "description" field for OpenSea - e.g. "A Nifty Ink by 0xE09750abE36beA8B2236E48C84BB9da7Ef5aA07c on Sat, 11 Jul 2020 19:49:42 GMT" (or will use ENS name if there is one)
- Turning the Limit field into a string (so OpenSea doesn't show it as a rank) - and add handling so the mint limit logic still works in the app
- Comment out the GSN meta transaction call (as we don't have the addresses from GSN yet)