### PR TITLE
Upgrade node-watch package version

### DIFF
--- a/packages/buidler/package.json
+++ b/packages/buidler/package.json
@@ -19,7 +19,7 @@
     "chalk": "^4.1.0",
     "ethereum-waffle": "^3.0.2",
     "ethers": "^5.0.7",
-    "node-watch": "^0.6.3"
+    "node-watch": "^0.6.4"
   },
   "scripts": {
     "chain": "buidler node",


### PR DESCRIPTION
Linux and recursively with node 14 throws TypeError [ERR_FEATURE_UNAVAILABLE_ON_PLATFORM] in node-watch v0.6.3

Issue was patched in v0.6.4

Issue referred to here: [https://github.com/yuanchuan/node-watch/issues/94](https://github.com/yuanchuan/node-watch/issues/94)


![image](https://user-images.githubusercontent.com/23085140/90911053-15234080-e3e1-11ea-9012-a1eb9f94f16c.png)
