### PR TITLE
React canvas object as a global var

### DIFF
--- a/packages/react-app/src/InkCanvas.js
+++ b/packages/react-app/src/InkCanvas.js
@@ -71,6 +71,7 @@ export default function InkCanvas(props) {
       }catch(e){console.log("Drawing Error:",e)}
     }
   }
+  window.drawingCanvas = drawingCanvas
   showDrawing()
 }, [props.ipfsHash])
 

--- a/packages/react-app/src/InkCanvas.js
+++ b/packages/react-app/src/InkCanvas.js
@@ -45,6 +45,7 @@ export default function InkCanvas(props) {
           }
         }
     }
+    window.drawingCanvas = drawingCanvas
     loadPage()
   }, [])
 
@@ -71,7 +72,6 @@ export default function InkCanvas(props) {
       }catch(e){console.log("Drawing Error:",e)}
     }
   }
-  window.drawingCanvas = drawingCanvas
   showDrawing()
 }, [props.ipfsHash])
 
@@ -384,6 +384,7 @@ return (
   disabled={props.mode !== "edit"}
   hideGrid={props.mode !== "edit"}
   hideInterface={props.mode !== "edit"}
+  imgSrc={"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/ETHEREUM-YOUTUBE-PROFILE-PIC.png/768px-ETHEREUM-YOUTUBE-PROFILE-PIC.png"}
   onChange={(newDrawing) => {
     let savedData = LZ.compress(newDrawing.getSaveData())
     props.setDrawing(savedData)

--- a/packages/react-app/src/InkCanvas.js
+++ b/packages/react-app/src/InkCanvas.js
@@ -384,7 +384,6 @@ return (
   disabled={props.mode !== "edit"}
   hideGrid={props.mode !== "edit"}
   hideInterface={props.mode !== "edit"}
-  imgSrc={"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/ETHEREUM-YOUTUBE-PROFILE-PIC.png/768px-ETHEREUM-YOUTUBE-PROFILE-PIC.png"}
   onChange={(newDrawing) => {
     let savedData = LZ.compress(newDrawing.getSaveData())
     props.setDrawing(savedData)


### PR DESCRIPTION
This change makes it easy to play with react-canvas-draw from JS console.

Here is a snippet how that works:

```
drawingCanvas.current.points = [{x:0, y:0}, {x:drawingCanvas.current.canvas.drawing.width, y:drawingCanvas.current.canvas.drawing.height}]

drawingCanvas.current.saveLine({
    brushColor: drawingCanvas.current.props.brushColor,
    brushRadius: drawingCanvas.current.props.brushRadius
})

drawingCanvas.current.simulateDrawingLines({
    lines: drawingCanvas.current.lines,
    immediate: true
})
```

And the result:

https://nifty.ink/QmZBxNgPEWS3oQhuqHqxm6dM8iH8YbUreqSzcNGiEz1hmV

I tested it with my local front-end and xdai network