### PR TITLE
Add a mechanism for cleanly supporting interface files

### DIFF
--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -2,8 +2,9 @@ pragma solidity >=0.6.0 <0.7.0;
 
 import "hardhat/console.sol";
 //import "@openzeppelin/contracts/access/Ownable.sol"; //https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol
+import "./YourInterface.sol";
 
-contract YourContract {
+contract YourContract is YourInterface {
 
   event SetPurpose(address sender, string purpose);
 
@@ -13,7 +14,7 @@ contract YourContract {
     // what should we do on deploy?
   }
 
-  function setPurpose(string memory newPurpose) public {
+  function setPurpose(string memory newPurpose) public override {
     purpose = newPurpose;
     console.log(msg.sender,"set purpose to",purpose);
     emit SetPurpose(msg.sender, purpose);

--- a/packages/hardhat/contracts/YourInterface.sol
+++ b/packages/hardhat/contracts/YourInterface.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.6.0 <0.7.0;
+
+interface YourInterface {
+  function setPurpose(string calldata newPurpose) external;
+}

--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -87,6 +87,9 @@ module.exports = {
       }
     }
   },
+  contracts: {
+    interfaceFiles: ["YourInterface.sol"]
+  }
 };
 
 const DEBUG = false;

--- a/packages/hardhat/scripts/deploy.js
+++ b/packages/hardhat/scripts/deploy.js
@@ -37,8 +37,18 @@ const autoDeploy = async () => {
   // loop through each solidity file from config.path.sources and deploy it
   // abi encode any args, if found
   // ! do not use .forEach in place of this loop
+  const interfaceFiles = config.contracts.interfaceFiles || {};
   for (let i=0; i < contractList.length; i++) {
     const file = contractList[i];
+
+    if (interfaceFiles.indexOf(file) > -1) {
+      console.log(
+        " 📄 Skipping deploy of interface file",
+        chalk.cyan(file),
+      );
+      continue;
+    }
+
     const contractName = file.replace(".sol", "");
     const contractArgs = readArgsFile(contractName);
     const deployed = await deploy(contractName, contractArgs);

--- a/packages/hardhat/scripts/publish.js
+++ b/packages/hardhat/scripts/publish.js
@@ -62,8 +62,6 @@ function publishContract(contractName) {
       JSON.stringify(contract.abi, null, 2)
     );
 
-
-
     return true;
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
Currently `deploy.js` and `publish.js` automatically try to deploy and publish any `.sol` files they can find.  However interface files do not need to be deployed, and attempting to do so results in this error:

    NomicLabsHardhatPluginError: You are trying to create a contract
    factory for the contract YourInterface, which is abstract and
    can't be deployed.

So add a mechanism for skipping deployment and publishing, and make it easy to do this by adding interface files to `hardhat.config.js`.  Later we may want to consider automatically detecting interface files, but this is a simple solution for now.