### PR TITLE
Add SPDX-License-Identifier to fix remix warning

### DIFF
--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: UNLICENSED
+
 pragma solidity >=0.6.0 <0.7.0;
 
 import "hardhat/console.sol";


### PR DESCRIPTION
When editing in remix via remixd, this gives a clean compile.