### PR TITLE
Add autotest capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,11 @@ yarn run watch
 yarn run test
 ```
 
+Run autotest to automatically run a test file when it is changed. This workflow allows you to iterate on tests faster. It works particularly well with using the `it.only` syntax to isolate individual tests:
+```bash
+yarn run autotest
+```
+
 🗝 List your local accounts:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ship": "yarn workspace @scaffold-eth/react-app ship",
     "generate": "yarn workspace @scaffold-eth/hardhat generate",
     "account": "yarn workspace @scaffold-eth/hardhat account",
+    "autotest": "cd packages/hardhat && npx hardhat watch test",
     "mine": "cd packages/hardhat && npx hardhat mine",
     "wallet": "cd packages/hardhat && npx hardhat wallet",
     "fundedwallet": "cd packages/hardhat && npx hardhat fundedwallet",

--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const chalk = require("chalk");
 
 require("@nomiclabs/hardhat-waffle");
+require("hardhat-watcher");
 
 const { isAddress, getAddress, formatUnits, parseUnits } = utils;
 
@@ -101,6 +102,13 @@ module.exports = {
       }
     }
   },
+  watcher: {
+    test: {
+      tasks: [{ command:'test', params: {testFiles: ['{path}']} }],
+      files: ['./test/**/*'],
+      verbose: true
+    }
+  }
 };
 
 const DEBUG = false;

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -21,7 +21,8 @@
     "hardhat": "^2.0.6",
     "node-watch": "^0.7.0",
     "qrcode-terminal": "^0.12.0",
-    "ramda": "^0.27.1"
+    "ramda": "^0.27.1",
+    "hardhat-watcher": "git+https://github.com/NotRealAI/hardhat-watcher.git"
   },
   "scripts": {
     "chain": "hardhat node --hostname 0.0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5211,6 +5211,21 @@ chokidar@^3.0.2, chokidar@^3.3.0, chokidar@^3.4.0, chokidar@^3.4.1:
   optionalDependencies:
     fsevents "~2.1.2"
 
+chokidar@^3.4.3:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -8533,6 +8548,11 @@ fsevents@~2.1.1, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+fsevents@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
+  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
+
 fstream@>=1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
@@ -8970,6 +8990,12 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
+
+"hardhat-watcher@git+https://github.com/NotRealAI/hardhat-watcher.git":
+  version "2.1.0"
+  resolved "git+https://github.com/NotRealAI/hardhat-watcher.git#2b51216fd9d420b49bf86cadd94417027260b432"
+  dependencies:
+    chokidar "^3.4.3"
 
 hardhat@^2.0.6:
   version "2.0.7"


### PR DESCRIPTION
This change makes it so that using the command `yarn run autotest` a watcher will be started which will automatically run tests in a particular file upon changes. This allows for faster iteration on tests, especially in conjunction with using `it.only`. Inspired by testing using Guard in Ruby.

This pull request uses a slightly modified version of the plugin `hardhat-watcher` which is waiting on approval for merge in that repository.

[https://github.com/NotRealAI/hardhat-watcher](https://github.com/NotRealAI/hardhat-watcher)