### PR TITLE
feat: add gas estimation skipping ability and fork note for tenderly

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,7 +790,23 @@ tenderly export <transactionHash>
 ```
 Which will upload them to tenderly.co/dashboard!
 
+Tenderly also allows users to debug smart contracts deployed to a local fork of some network (see `yarn fork`). To let Tenderly know that we are dealing with a fork, run the following command:
+
+```
+tenderly export init
+```
+
+CLI will ask you for your network's name and whether you are forking a public network. After choosing the right fork, your exporting will look something like this:
+
+```
+tenderly export <transactionHash> --export-network <networkName>
+```
+
+Note that `tenderly.yaml` file stores information about all networks that you initialized for exporting transactions. There can be multiple of them in a single file.
+
 **A quick note on local contracts:** if your local contracts are persisted in a place that Tenderly can find them, then they will also be uploaded as part of the local transaction `export`, which is one of the freshest features! We have added a call to `tenderly.persistArtifacts()` as part of the scaffold-eth deploy() script, which stores the contracts & meta-information in a `deployments` folder, so this should work out of the box.
+
+Another pitfall when dealing with a local network (fork or not) is that you will not see the transaction hash if it fails. This happens because the hardhat detects an error while `eth_estimateGas` is executed. To prevent such behaviour, you can skip this estimation by uncommenting `gasLimit` override in `FunctionForm.jsx` component.
 
 **One gotcha** - Tenderly does not (currently) support yarn workspaces, so any imported solidity contracts need to be local to `packages/hardhat` for your contracts to be exported. You can achieve this by using [`nohoist`](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/) - this has been done for `hardhat` so that we can export `console.sol` - see the top-level `package.json` to see how!
 ```

--- a/packages/react-app/src/components/Contract/FunctionForm.jsx
+++ b/packages/react-app/src/components/Contract/FunctionForm.jsx
@@ -3,6 +3,7 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
 import React, { useState } from "react";
 import { BigNumber } from "@ethersproject/bignumber";
+import { hexlify } from "@ethersproject/bytes";
 import { Row, Col, Input, Divider, Tooltip, Button } from "antd";
 import { Transactor } from "../../helpers";
 import tryToDisplay from "./utils";
@@ -202,6 +203,9 @@ export default function FunctionForm({ contractFunction, functionInfo, provider,
                 if (txValue) {
                   overrides.value = txValue; // ethers.utils.parseEther()
                 }
+                // Uncomment this if you want to skip the gas estimation for each transaction
+                // overrides.gasLimit = hexlify(1200000);
+
 
                 // console.log("Running with extras",extras)
                 const returned = await tx(contractFunction(...args, overrides));


### PR DESCRIPTION
Here is the minimal contract function that would show that the transaction hash is not shown. As a consequence, we will not be able to export it to Tenderly.

```
function getDivision(uint256 x, uint256 y) public returns (uint256) {
  uint256 result = x / y;
  map[msg.sender] = result;
   return result;
}
```

Pass `y` as 0.