### PR TITLE
Fixed the quickstart terminal commands order

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,8 @@ required: [Node](https://nodejs.org/dist/latest-v12.x/) plus [Yarn](https://clas
 
 ```bash
 git clone https://github.com/austintgriffith/scaffold-eth.git
-
 cd scaffold-eth
-```
-
-```bash
-
-yarn install
-
-```
-
-```bash
-
-yarn start
+yarn chain
 
 ```
 
@@ -79,7 +68,8 @@ yarn start
 
 ```bash
 cd scaffold-eth
-yarn chain
+yarn install
+yarn start
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,17 +60,15 @@ required: [Node](https://nodejs.org/dist/latest-v12.x/) plus [Yarn](https://clas
 ```bash
 git clone https://github.com/austintgriffith/scaffold-eth.git
 cd scaffold-eth
+yarn install
 yarn chain
-
 ```
 
 > in a second terminal window:
 
 ```bash
 cd scaffold-eth
-yarn install
 yarn start
-
 ```
 
 > in a third terminal window:
@@ -78,7 +76,6 @@ yarn start
 ```bash
 cd scaffold-eth
 yarn deploy
-
 ```
 
 🔏 Edit your smart contract `YourContract.sol` in `packages/hardhat/contracts`


### PR DESCRIPTION
Inverted the order on which the node and the react app is start.

Currently the react app was started first and it was throwing an error, because it was not finding the node running yet. As per described in [Issue 129](https://github.com/austintgriffith/scaffold-eth/issues/129).