### PR TITLE
Use the correct prop as a key in Ramp.jsx

### DIFF
--- a/packages/react-app/src/components/Ramp.jsx
+++ b/packages/react-app/src/components/Ramp.jsx
@@ -34,7 +34,7 @@ export default function Ramp(props) {
   for(let n in props.networks){
     if(props.networks[n].chainId!=31337&&props.networks[n].chainId!=1){
       allFaucets.push(
-        <p key={props.networks[n].id}>
+        <p key={props.networks[n].chainId}>
           <Button
             style={{color:props.networks[n].color}}
             type={type}


### PR DESCRIPTION
Was throwing an error because the keys were not unique (all `undefined`). I think `chainId` was the intended key.


Thank you for the unbelievably amazing project, by the way :smile: 