### PR TITLE
Polling fixes - reduce polling intensity

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -7,7 +7,7 @@ import { Row, Col, Button, Menu, Alert, Switch as SwitchD } from "antd";
 import Web3Modal from "web3modal";
 import WalletConnectProvider from "@walletconnect/web3-provider";
 import { useUserAddress } from "eth-hooks";
-import { useExchangePrice, useGasPrice, useUserProvider, useContractLoader, useContractReader, useEventListener, useBalance, useExternalContractLoader } from "./hooks";
+import { useExchangePrice, useGasPrice, useUserProvider, useContractLoader, useContractReader, useEventListener, useBalance, useExternalContractLoader, useOnBlock } from "./hooks";
 import { Header, Account, Faucet, Ramp, Contract, GasGauge, ThemeSwitch } from "./components";
 import { Transactor } from "./helpers";
 import { formatEther, parseEther } from "@ethersproject/units";
@@ -107,6 +107,11 @@ function App(props) {
   //
   // If you want to bring in the mainnet DAI contract it would look like:
   const mainnetDAIContract = useExternalContractLoader(mainnetProvider, DAI_ADDRESS, DAI_ABI)
+
+  // If you want to call a function on a new block
+  useOnBlock(mainnetProvider, () => {
+    console.log(`⛓ A new mainnet block is here: ${mainnetProvider._lastBlockNumber}`)
+  })
 
   // Then read your DAI balance like:
   const myMainnetDAIBalance = useContractReader({DAI: mainnetDAIContract},"DAI", "balanceOf",["0x34aA3F359A9D614239015126635CE7732c18fDF3"])

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { BrowserRouter, Switch, Route, Link } from "react-router-dom";
 import "antd/dist/antd.css";
-import {  JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import {  StaticJsonRpcProvider, JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
 import "./App.css";
 import { Row, Col, Button, Menu, Alert, Switch as SwitchD } from "antd";
 import Web3Modal from "web3modal";
@@ -48,8 +48,9 @@ if(DEBUG) console.log("📡 Connecting to Mainnet Ethereum");
 // const mainnetProvider = new InfuraProvider("mainnet",INFURA_ID);
 //
 // attempt to connect to our own scaffold eth rpc and if that fails fall back to infura...
-const scaffoldEthProvider = new JsonRpcProvider("https://rpc.scaffoldeth.io:48544")
-const mainnetInfura = new JsonRpcProvider("https://mainnet.infura.io/v3/" + INFURA_ID)
+// Using StaticJsonRpcProvider as the chainId won't change see https://github.com/ethers-io/ethers.js/issues/901
+const scaffoldEthProvider = new StaticJsonRpcProvider("https://rpc.scaffoldeth.io:48544")
+const mainnetInfura = new StaticJsonRpcProvider("https://mainnet.infura.io/v3/" + INFURA_ID)
 // ( ⚠️ Getting "failed to meet quorum" errors? Check your INFURA_I
 
 // 🏠 Your local provider is usually pointed at your local blockchain
@@ -57,7 +58,7 @@ const localProviderUrl = targetNetwork.rpcUrl;
 // as you deploy to other networks you can set REACT_APP_PROVIDER=https://dai.poa.network in packages/react-app/.env
 const localProviderUrlFromEnv = process.env.REACT_APP_PROVIDER ? process.env.REACT_APP_PROVIDER : localProviderUrl;
 if(DEBUG) console.log("🏠 Connecting to provider:", localProviderUrlFromEnv);
-const localProvider = new JsonRpcProvider(localProviderUrlFromEnv);
+const localProvider = new StaticJsonRpcProvider(localProviderUrlFromEnv);
 
 
 // 🔭 block explorer URL
@@ -433,14 +434,14 @@ const logoutOfWeb3Modal = async () => {
 };
 
  window.ethereum && window.ethereum.on('chainChanged', chainId => {
-  web3Modal.cachedProvider && 
+  web3Modal.cachedProvider &&
   setTimeout(() => {
     window.location.reload();
   }, 1);
 })
 
  window.ethereum && window.ethereum.on('accountsChanged', accounts => {
-  web3Modal.cachedProvider && 
+  web3Modal.cachedProvider &&
   setTimeout(() => {
     window.location.reload();
   }, 1);

--- a/packages/react-app/src/components/Balance.jsx
+++ b/packages/react-app/src/components/Balance.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { formatEther } from "@ethersproject/units";
 import { usePoller } from "eth-hooks";
+import { useBalance } from "../hooks"
 
 /*
   ~ What it does? ~
@@ -31,25 +32,10 @@ import { usePoller } from "eth-hooks";
 
 export default function Balance(props) {
   const [dollarMode, setDollarMode] = useState(true);
-  const [balance, setBalance] = useState();
 
-  const getBalance = async () => {
-    if (props.address && props.provider) {
-      try {
-        const newBalance = await props.provider.getBalance(props.address);
-        setBalance(newBalance);
-      } catch (e) {
-        console.log(e);
-      }
-    }
-  };
+  const [listening, setListening] = useState(false);
 
-  usePoller(
-    () => {
-      getBalance();
-    },
-    props.pollTime ? props.pollTime : 1999,
-  );
+  const balance = useBalance(props.provider, props.address)
 
   let floatBalance = parseFloat("0.00");
 

--- a/packages/react-app/src/hooks/Balance.js
+++ b/packages/react-app/src/hooks/Balance.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import usePoller from "./Poller";
 
 /*
@@ -16,18 +16,33 @@ import usePoller from "./Poller";
   - Change provider to access balance on different chains (ex. mainnetProvider)
 */
 
-export default function useBalance(provider, address, pollTime) {
+export default function useBalance(provider, address) {
+
 const [balance, setBalance] = useState();
-const pollBalance = async () => {
-  if (address && provider) {
+
+const pollBalance = useCallback(async (provider, address) => {
+  if (provider && address) {
     const newBalance = await provider.getBalance(address);
     if (newBalance !== balance) {
-      // console.log("NEW BALANCE:",newBalance,"Current balance",balance)
       setBalance(newBalance);
     }
   }
-};
-usePoller(pollBalance, 27777, address && provider );
+}, [provider, address]);
+
+useEffect(() => {
+  if (provider && address) {
+    pollBalance(provider, address);
+
+    const listener = (blockNumber) => {
+      pollBalance(provider, address);
+    }
+
+    provider.on("block", listener)
+    return () => {
+      provider.off("block", listener)
+  }
+}
+},[provider, address])
 
 return balance;
 }

--- a/packages/react-app/src/hooks/Balance.js
+++ b/packages/react-app/src/hooks/Balance.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import usePoller from "./Poller";
+import useOnBlock from "./OnBlock";
 
 /*
   ~ What it does? ~
@@ -14,9 +15,12 @@ import usePoller from "./Poller";
 
   - Provide address and get balance corresponding to given address
   - Change provider to access balance on different chains (ex. mainnetProvider)
+  - If no pollTime is passed, the balance will update on every new block
 */
 
-export default function useBalance(provider, address) {
+let DEBUG = false
+
+export default function useBalance(provider, address, pollTime = 0) {
 
 const [balance, setBalance] = useState();
 
@@ -29,20 +33,20 @@ const pollBalance = useCallback(async (provider, address) => {
   }
 }, [provider, address]);
 
-useEffect(() => {
-  if (provider && address) {
+// Only pass a provider to watch on a block if there is no pollTime
+useOnBlock((pollTime === 0)&&provider, () => {
+  if (provider && address && pollTime === 0) {
     pollBalance(provider, address);
-
-    const listener = (blockNumber) => {
-      pollBalance(provider, address);
-    }
-
-    provider.on("block", listener)
-    return () => {
-      provider.off("block", listener)
-  }
 }
-},[provider, address])
+})
+
+// Use a poller if a pollTime is provided
+usePoller(async () => {
+  if (provider && address && pollTime > 0) {
+    if (DEBUG) console.log('polling!', address)
+    pollBalance()
+  }
+}, pollTime, provider && address)
 
 return balance;
 }

--- a/packages/react-app/src/hooks/ContractReader.js
+++ b/packages/react-app/src/hooks/ContractReader.js
@@ -63,7 +63,7 @@ export default function useContractReader(contracts, contractName, functionName,
   if (contracts && contracts[contractName] && adjustPollTime === 0) {
 
     const listener = (blockNumber) => {
-      console.log(blockNumber, contractName, functionName, contracts[contractName].provider.listeners())
+      if (DEBUG) console.log(blockNumber, contractName, functionName, contracts[contractName].provider.listeners())
       updateValue()
     }
 
@@ -77,7 +77,7 @@ export default function useContractReader(contracts, contractName, functionName,
 
 usePoller(async () => {
   if (contracts && contracts[contractName] && adjustPollTime > 0) {
-    console.log('polling!', contractName, functionName)
+    if (DEBUG) console.log('polling!', contractName, functionName)
     updateValue()
   }
 }, adjustPollTime, contracts && contracts[contractName])

--- a/packages/react-app/src/hooks/LookupAddress.js
+++ b/packages/react-app/src/hooks/LookupAddress.js
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import { getAddress } from "@ethersproject/address";
+import { getAddress, isAddress } from "@ethersproject/address";
 import { useLocalStorage } from "."
 
-// resolved if(name){} to not save "" into cache 
+// resolved if(name){} to not save "" into cache
 
 /*
   ~ What it does? ~
@@ -19,18 +19,22 @@ import { useLocalStorage } from "."
 */
 
 const lookupAddress = async (provider, address) => {
-  try {
-    // Accuracy of reverse resolution is not enforced.
-    // We then manually ensure that the reported ens name resolves to address
-    const reportedName = await provider.lookupAddress(address);
-    
-    const resolvedAddress = await provider.resolveName(reportedName);
+  if(isAddress(address)) {
+    try {
+      // Accuracy of reverse resolution is not enforced.
+      // We then manually ensure that the reported ens name resolves to address
+      const reportedName = await provider.lookupAddress(address);
 
-    if (getAddress(address) === getAddress(resolvedAddress)) {
-      return reportedName;
+      const resolvedAddress = await provider.resolveName(reportedName);
+
+      if (getAddress(address) === getAddress(resolvedAddress)) {
+        return reportedName;
+      } else {
+        return getAddress(address)
+      }
+    } catch (e) {
+      return getAddress(address)
     }
-  } catch (e) {
-    // Do nothing
   }
   return 0;
 };

--- a/packages/react-app/src/hooks/LookupAddress.js
+++ b/packages/react-app/src/hooks/LookupAddress.js
@@ -20,6 +20,7 @@ import { useLocalStorage } from "."
 
 const lookupAddress = async (provider, address) => {
   if(isAddress(address)) {
+    //console.log(`looking up ${address}`)
     try {
       // Accuracy of reverse resolution is not enforced.
       // We then manually ensure that the reported ens name resolves to address
@@ -41,25 +42,29 @@ const lookupAddress = async (provider, address) => {
 
 const useLookupAddress = (provider, address) => {
   const [ensName, setEnsName] = useState(address);
-  const [ensCache, setEnsCache] = useLocalStorage('ensCache_'+address);
+  //const [ensCache, setEnsCache] = useLocalStorage('ensCache_'+address); Writing directly due to sync issues
 
   useEffect(() => {
-    if( ensCache && ensCache.timestamp>Date.now()){
-      setEnsName(ensCache.name)
+
+    let cache = window.localStorage.getItem('ensCache_'+address);
+    cache = cache && JSON.parse(cache)
+
+    if( cache && cache.timestamp>Date.now()){
+      setEnsName(cache.name)
     }else{
       if (provider) {
         lookupAddress(provider, address).then((name) => {
           if (name) {
             setEnsName(name);
-            setEnsCache({
+            window.localStorage.setItem('ensCache_'+address, JSON.stringify({
               timestamp:Date.now()+360000,
               name:name
-            })
+            }))
           }
         });
       }
     }
-  }, [ensCache, provider, address, setEnsName, setEnsCache]);
+  }, [provider, address, setEnsName]);
 
   return ensName;
 };

--- a/packages/react-app/src/hooks/OnBlock.js
+++ b/packages/react-app/src/hooks/OnBlock.js
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+
+// helper hook to call a function regularly in time intervals
+let DEBUG = false
+
+export default function useOnBlock(provider, fn, args) {
+  const savedCallback = useRef();
+  // Remember the latest fn.
+  useEffect(() => {
+    savedCallback.current = fn;
+  }, [fn]);
+
+  // Turn on the listener if we have a function & a provider
+  useEffect(() => {
+  if (fn && provider) {
+
+    const listener = (blockNumber) => {
+      if (DEBUG) console.log(blockNumber, fn, args, provider.listeners())
+
+      if (args && args.length > 0) {
+        savedCallback.current(...args);
+      } else {
+        savedCallback.current();
+      }
+
+    }
+
+    provider.on("block", listener)
+
+    return () => {
+        provider.off("block", listener)
+    }
+}
+},[provider])
+}

--- a/packages/react-app/src/hooks/Poller.js
+++ b/packages/react-app/src/hooks/Poller.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-// helper hook to call a function regularly in time intervals 
+// helper hook to call a function regularly in time intervals
 
 export default function usePoller(fn, delay, extraWatch) {
   const savedCallback = useRef();
@@ -11,7 +11,6 @@ export default function usePoller(fn, delay, extraWatch) {
   // Set up the interval.
   // eslint-disable-next-line consistent-return
   useEffect(() => {
-    console.log("tick")
     function tick() {
       savedCallback.current();
     }

--- a/packages/react-app/src/hooks/index.js
+++ b/packages/react-app/src/hooks/index.js
@@ -15,3 +15,4 @@ export { default as useResolveName } from "./ResolveName";
 export { default as useNonce } from "./Nonce";
 export { default as useTokenList } from "./TokenList";
 export { default as useDebounce } from "./Debounce";
+export { default as useOnBlock } from "./OnBlock";


### PR DESCRIPTION
- StaticJsonRpcProvider to reduce chainId polling (see this ethers issue https://github.com/ethers-io/ethers.js/issues/901 -this is fine in cases where we know the chainid is not going to change)
- Update useBalance and useContractReader to update on every new block, rather than on a set polling interval (using ethers.js `provider.on('block',listener)`
- Cache ENS for when we don't resolve a name to stop trying to fetch (we were only caching names that we resolved) - this is still a bit of a sprawling implementation in the local storage)
- Standardised the balance component to use `useBalance` (it had a home grown implementation)