### PR TITLE
chore: create new useLatestRef helper hook

### DIFF
--- a/packages/react-app/src/hooks/LatestRef.js
+++ b/packages/react-app/src/hooks/LatestRef.js
@@ -1,0 +1,23 @@
+import { useLayoutEffect, useRef} from "react";
+
+/*
+  ~ What it does? ~
+
+  Keeps a stable reference to a value, that persists between renders
+
+  This is good for enabling non-primitive values to be used inside
+  hooks that have a dependency array, without invalidating the hook
+  on every render.
+*/
+
+const useLatestRef = (value) => {
+  const ref = useRef(value)
+
+  useLayoutEffect(() => {
+    ref.current = value
+  }, [value]);
+  
+  return ref;
+};
+
+export default useLatestRef;

--- a/packages/react-app/src/hooks/LatestRef.js
+++ b/packages/react-app/src/hooks/LatestRef.js
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef} from "react";
+import { useLayoutEffect, useRef } from "react";
 
 /*
   ~ What it does? ~
@@ -10,13 +10,13 @@ import { useLayoutEffect, useRef} from "react";
   on every render.
 */
 
-const useLatestRef = (value) => {
-  const ref = useRef(value)
+const useLatestRef = value => {
+  const ref = useRef(value);
 
   useLayoutEffect(() => {
-    ref.current = value
+    ref.current = value;
   }, [value]);
-  
+
   return ref;
 };
 

--- a/packages/react-app/src/hooks/OnBlock.js
+++ b/packages/react-app/src/hooks/OnBlock.js
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import { useLatestRef } from 'eth-hooks';
+import { useEffect } from "react";
+import { useLatestRef } from "eth-hooks";
 
 // helper hook to call a function regularly in time intervals
 const DEBUG = false;

--- a/packages/react-app/src/hooks/OnBlock.js
+++ b/packages/react-app/src/hooks/OnBlock.js
@@ -9,6 +9,7 @@ export default function useOnBlock(provider, fn, args) {
   const savedCallback = useLatestRef(fn);
 
   // Turn on the listener if we have a function & a provider
+  // eslint-disable-next-line consistent-return
   useEffect(() => {
     if (fn && provider) {
       const listener = blockNumber => {

--- a/packages/react-app/src/hooks/OnBlock.js
+++ b/packages/react-app/src/hooks/OnBlock.js
@@ -1,14 +1,12 @@
 import { useEffect, useRef } from "react";
+import { useLatestRef } from 'eth-hooks';
 
 // helper hook to call a function regularly in time intervals
 const DEBUG = false;
 
 export default function useOnBlock(provider, fn, args) {
-  const savedCallback = useRef();
   // Remember the latest fn.
-  useEffect(() => {
-    savedCallback.current = fn;
-  }, [fn]);
+  const savedCallback = useLatestRef(fn);
 
   // Turn on the listener if we have a function & a provider
   useEffect(() => {
@@ -29,5 +27,5 @@ export default function useOnBlock(provider, fn, args) {
         provider.off("block", listener);
       };
     }
-  }, [provider]);
+  }, [provider, savedCallback]);
 }

--- a/packages/react-app/src/hooks/Poller.js
+++ b/packages/react-app/src/hooks/Poller.js
@@ -1,13 +1,10 @@
 import { useEffect, useRef } from "react";
+import { useLatestRef } from 'eth-hooks';
 
 // helper hook to call a function regularly in time intervals
 
 export default function usePoller(fn, delay, extraWatch) {
-  const savedCallback = useRef();
-  // Remember the latest fn.
-  useEffect(() => {
-    savedCallback.current = fn;
-  }, [fn]);
+  const savedCallback = useLatestRef();
   // Set up the interval.
   // eslint-disable-next-line consistent-return
   useEffect(() => {
@@ -18,7 +15,7 @@ export default function usePoller(fn, delay, extraWatch) {
       const id = setInterval(tick, delay);
       return () => clearInterval(id);
     }
-  }, [delay]);
+  }, [delay, savedCallback]);
   // run at start too
   useEffect(() => {
     fn();

--- a/packages/react-app/src/hooks/Poller.js
+++ b/packages/react-app/src/hooks/Poller.js
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import { useLatestRef } from 'eth-hooks';
+import { useEffect } from "react";
+import { useLatestRef } from "eth-hooks";
 
 // helper hook to call a function regularly in time intervals
 

--- a/packages/react-app/src/hooks/index.js
+++ b/packages/react-app/src/hooks/index.js
@@ -16,3 +16,4 @@ export { default as usePoller } from "./Poller";
 export { default as useResolveName } from "./ResolveName";
 export { default as useTokenList } from "./TokenList";
 export { default as useUserProvider } from "./UserProvider";
+export { default as useLatestRef } from "./LatestRef";


### PR DESCRIPTION
This PR adds a new helper hook to help keep track of non-primitive values and keep a stable reference, while still remembering the latest value