### PR TITLE
Update balance when provider / address changes

### DIFF
--- a/packages/react-app/src/hooks/Balance.js
+++ b/packages/react-app/src/hooks/Balance.js
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect } from "react";
 import useOnBlock from "./OnBlock";
 import usePoller from "./Poller";
 
@@ -41,6 +41,11 @@ export default function useBalance(provider, address, pollTime = 0) {
       pollBalance(provider, address);
     }
   });
+
+  // Update balance when the address or provider changes
+  useEffect(() => {
+    if (address && provider) pollBalance(provider, address);
+  }, [address, provider, pollBalance]);
 
   // Use a poller if a pollTime is provided
   usePoller(


### PR DESCRIPTION
Balances are only updated when there is a new block. This is especially strange during local development where you don't get new blocks on an ongoing basis. This change updates the balance when the provider or address changes