### PR TITLE
Fix yarn fork

### DIFF
--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "chain": "hardhat node --network hardhat --no-deploy",
-    "fork": "hardhat node --fork https://mainnet.infura.io/v3/460f40a260564ac4a4f4b3fffb032dad",
+    "fork": "hardhat node --no-deploy --network hardhat --fork https://mainnet.infura.io/v3/460f40a260564ac4a4f4b3fffb032dad",
     "test": "hardhat test --network hardhat",
     "compile": "hardhat compile",
     "deploy": "hardhat deploy --export-all ../react-app/src/contracts/hardhat_contracts.json",


### PR DESCRIPTION
Reported in the scaffold-eth chat, Hardhat fork requires specifying `--network hardhat`. This also adds the no-deploy flag so contracts aren't auto-deployed