### PR TITLE
Fixed Infinite loop bug in useContractReader hook

### DIFF
--- a/packages/react-app/src/hooks/ContractReader.js
+++ b/packages/react-app/src/hooks/ContractReader.js
@@ -50,6 +50,7 @@ export default function useContractReader(contracts, contractName, functionName,
         if (DEBUG)
           console.log("contractName", contractName, "functionName", functionName, "args", args, "RESULT:", newValue);
       } else {
+        setTried(true);
         newValue = await contracts[contractName][functionName]();
       }
       if (formatter && typeof formatter === "function") {


### PR DESCRIPTION
If the contract function that we are calling has no arguments and we provide a pollTime, then tried state variable is never set to true, this results in an infinite loop of contract reads.