### PR TITLE
Add catch to DAI price fetch to prevent page crash

### DIFF
--- a/packages/react-app/src/hooks/ExchangePrice.js
+++ b/packages/react-app/src/hooks/ExchangePrice.js
@@ -7,8 +7,7 @@ export default function useExchangePrice(targetNetwork, mainnetProvider, pollTim
 
   const pollPrice = () => {
     async function getPrice() {
-      if(!mainnetProvider)
-        return 0;
+      if (!mainnetProvider) return 0;
       if (targetNetwork.price) {
         setPrice(targetNetwork.price);
       } else {
@@ -17,9 +16,13 @@ export default function useExchangePrice(targetNetwork, mainnetProvider, pollTim
           "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           18,
         );
-        const pair = await Fetcher.fetchPairData(DAI, WETH[DAI.chainId], mainnetProvider);
-        const route = new Route([pair], WETH[DAI.chainId]);
-        setPrice(parseFloat(route.midPrice.toSignificant(6)));
+        const pair = await Fetcher.fetchPairData(DAI, WETH[DAI.chainId], mainnetProvider).catch(e => {
+          console.error("DAI fetch fail: ", e);
+        });
+        if (pair !== undefined) {
+          const route = new Route([pair], WETH[DAI.chainId]);
+          setPrice(parseFloat(route.midPrice.toSignificant(6)));
+        }
       }
     }
     getPrice();


### PR DESCRIPTION
resolve #308 preventing users from using the UI if the UniSwap fetch fails it's price retrieval.