### PR TITLE
New network: Harmony ONE

### DIFF
--- a/packages/hardhat/hardhat.config.js
+++ b/packages/hardhat/hardhat.config.js
@@ -185,6 +185,22 @@ module.exports = {
         mnemonic: mnemonic(),
       },
     },
+    testnetHarmony: {
+      url: "https://api.s0.b.hmny.io",
+      gasPrice: 1000000000,
+      chainId: 1666700000,
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+    },
+    mainnetHarmony: {
+      url: "https://api.harmony.one",
+      gasPrice: 1000000000,
+      chainId: 1666600000,
+      accounts: {
+        mnemonic: mnemonic(),
+      },
+    },
   },
   solidity: {
     compilers: [

--- a/packages/react-app/src/constants.js
+++ b/packages/react-app/src/constants.js
@@ -167,6 +167,22 @@ export const NETWORKS = {
     rpcUrl: `https://api.avax.network/ext/bc/C/rpc`,
     gasPrice: 225000000000,
   },
+  testnetHarmony: {
+    name: "Harmony Testnet",
+    color: "#00b0ef",
+    chainId: 1666700000,
+    blockExplorer: "https://explorer.pops.one/",
+    rpcUrl: `https://api.s0.b.hmny.io`,
+    gasPrice: 1000000000,
+  },
+  mainnetHarmony: {
+    name: "Harmony Mainnet",
+    color: "#00b0ef",
+    chainId: 1666600000,
+    blockExplorer: "https://explorer.harmony.one/",
+    rpcUrl: `https://api.harmony.one`,
+    gasPrice: 1000000000,
+  },
 };
 
 export const NETWORK = chainId => {


### PR DESCRIPTION
## Change Details
Added Harmony testnet + mainnet networks. I have tested this end-to-end. Contract deployment and UI network switching function as expected. `yarn account` returns the correct balance.

## About Harmony
[Harmony](https://www.harmony.one) is a sharded and open blockchain. Harmony is 100% EVM compatible and runs Ethereum applications with 2-second transaction finality and 100 times lower fees.

## Network UI Preview
![Image 2021-08-19 at 8 52 18 PM](https://user-images.githubusercontent.com/205550/130176802-4e2a2dfd-0687-430e-9116-b476df4bcd78.jpg)
