### PR TITLE
fix switching chains in metamask

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -323,9 +323,28 @@ function App(props) {
                       },
                     ];
                     console.log("data", data);
-                    const tx = await ethereum.request({ method: "wallet_addEthereumChain", params: data }).catch();
-                    if (tx) {
-                      console.log(tx);
+
+                    let switchTx;
+                    // https://docs.metamask.io/guide/rpc-api.html#other-rpc-methods
+                    try {
+                      switchTx = await ethereum.request({
+                        method: 'wallet_switchEthereumChain',
+                        params: [{ chainId: data[0].chainId }],
+                      });
+                    } catch (switchError) {
+                      // not checking specific error code, because maybe we're not using MetaMask
+                      try {
+                        switchTx = await ethereum.request({
+                          method: 'wallet_addEthereumChain',
+                          params: data,
+                        });
+                      } catch (addError) {
+                        // handle "add" error
+                      }
+                    }
+                    
+                    if (switchTx) {
+                      console.log(switchTx);
                     }
                   }}
                 >


### PR DESCRIPTION
Uses `wallet_switchEthereumChain` before trying `wallet_addEthereumChain` according to [MM recommendation](https://docs.metamask.io/guide/rpc-api.html#usage-with-wallet-switchethereumchain)

A bit more details: `wallet_addEthereumChain` is for adding a chain, which fails for default chains (because chain are already in MM) and for localhost (because it's not HTTPS). The recommended method is to try and use the "switch" method, and if that - try adding a chain.

Testing: manually checking switching back and forth between a few networks, with MM only, so not sure how it will behave with other browser wallets.